### PR TITLE
Update WORLD v0.2.1-2 and handle compatibility issue

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ deps = [
         world = library_dependency("libworld")
         ]
 
-const version = "0.2.0_1"
+const version = "0.2.1-2"
 
 provides(Sources,
          URI("https://github.com/r9y9/WORLD/archive/v$(version).tar.gz"),

--- a/src/WORLD.jl
+++ b/src/WORLD.jl
@@ -33,6 +33,34 @@ else
     error("WORLD not properly installed. Please run Pkg.build(\"WORLD\")")
 end
 
+try
+    # function GetWORLDVersion was added in v0.2.1-2
+    versionstr = bytestring(ccall((:GetWORLDVersion, libworld), Ptr{Cchar}, ()))
+    global const version = convert(VersionNumber, versionstr)
+catch e
+    try
+        ccall((:GetFFTSizeForStar, libworld), Int, (Int,), 48000)
+        global const version = v"0.1.4"
+    catch e
+        global const version = v"0.2.0"
+    end
+end
+
+if version < v"0.2.0"
+    warn("""WORLD version incompatibility
+
+         WORLD version 0.2.0 or later is recommended, but the detected version
+         is $(version)). If you have WORLD installed, please get the latest
+         stable WORLD and upgrade it, or re-build WORLD.jl with the following
+         commands from REPL:
+
+         julia> rm(joinpath(Pkg.dir(\"WORLD\"),  \"deps\", \"deps.jl\"))
+         julia> Pkg.build(\"WORLD\")
+
+         This should install the proper version of WORLD.
+         """)
+end
+
 include("bridge.jl")
 include("mcep.jl")
 include("deprecated.jl")

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -9,7 +9,11 @@ x = vec(readdlm(joinpath(dirname(@__FILE__), "data", "x.txt")))
 
 fs = 16000
 period = 5.0
-opt = DioOption(71.0, 800.0, 2, period, 1)
+if WORLD.version >= v"0.2.1-2"
+    opt = DioOption(71.0, 800.0, 2, period, 1, 0.1) # 0.1 = 0.02 * 5.0
+else
+    opt = DioOption(71.0, 800.0, 2, period, 1)
+end
 
 # Fundamental frequency (f0) estimation by DIO
 f0, timeaxis = dio(x, fs, opt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using WORLD
 using Base.Test
 
+@show WORLD.version
+
 # Check consistency of the results between WORLD and WORLD.jl.
 # Due to the results of the WORLD were dumped (see ./data) on linux,
 # we test consistency only on linux.
@@ -169,6 +171,12 @@ let
     try DioOption(80.0, 640.0, 2.0, 5.0, 12); catch @test false; end
     @test_throws ArgumentError DioOption(80.0, 640.0, 2.0, 5.0, 0)
     @test_throws ArgumentError DioOption(80.0, 640.0, 2.0, 5.0, 13)
+    # allowed_range
+    if WORLD.version >= v"0.2.1-2"
+        try DioOption(allowed_range=0.1); catch @test false; end
+        try DioOption(71.0, 800.0, 2.0, 5.0, 1, 0.0); catch @test false; end
+        @test_throws ArgumentError DioOption(80.0, 640.0, 2.0, 5.0, 0, -1.0)
+    end
 end
 
 # matlabfunctions


### PR DESCRIPTION
This changes are made to keep compatibility for update to `v0.2.1-2` from `v0.2.0_1` (for versioning semantic reason,  I note `v0.2.0_2` as `v0.2.1-2`), especially the `DioOption` change. A new field `allowed_range` was added to struct `DioOption` in C.

### Summary

- Update library dependency to the WORLD `v0.2.1-2` from `v0.2.0_1`
- Support both `DioOption` of `v0.2.1-2` and older one.
- Improve the binary dependency version check ( warn if the older version of WORLD is detected)