### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 0.3
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/src/WORLD.jl
+++ b/src/WORLD.jl
@@ -33,7 +33,7 @@ export
 
 
 ### Binary dependency loading ###
-deps = joinpath(Pkg.dir("WORLD"), "deps", "deps.jl")
+deps = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if isfile(deps)
     include(deps)
 else


### PR DESCRIPTION
so that the package can be installed elsewhere