### PR TITLE
Add spectral envelope code/decode API

### DIFF
--- a/src/WORLD.jl
+++ b/src/WORLD.jl
@@ -111,7 +111,7 @@ approximate_spectrogram = mc2sp(mc, α, get_fftsize_for_cheaptrick(fs))
 coded_aperiodicity = code_aperiodicity(aperiodicity, fs)
 ```
 
-![](assets/coded_melcepstrum.png)
+![](assets/coded_aperiodicity.png)
 
 #### Decode aperiodicity
 

--- a/src/WORLD.jl
+++ b/src/WORLD.jl
@@ -82,9 +82,10 @@ y = synthesis(f0, spectrogram, aperiodicity, period, fs, length(x))
 
 Raw spectrum envelope and aperiodicity spectrum are relatively high dimentional
 (offen more than 513 or 1025) so one might want to get more compact
-representation. To do so, mel-cepstrum could be a good choice. As far as I know,
-this would be useful in statistical speech synthesis and statistical voice
-conversion.
+representation. To handle this situation, WORLD provides coding/decoding APIs
+for spectrum envelope and aperiodicity. Additionally, WORLD.jl provides
+conversions from spectrum envelope to mel-cepstrum and vice versa. You can choose
+any of coding/decoding APIs depends on your purpose.
 
 #### spectrum envelope to mel-cepstrum
 
@@ -134,9 +135,10 @@ module WORLD
 using DocStringExtensions
 
 export DioOption, HarvestOption, CheapTrickOption, D4COption, dio, harvest,
-    stonemask, cheaptrick,
-    d4c, synthesis, get_fftsize_for_cheaptrick, interp1!, interp1, sp2mc, mc2sp,
-    get_number_of_aperiodicities, code_aperiodicity, decode_aperiodicity
+    stonemask, cheaptrick, d4c, synthesis, get_fftsize_for_cheaptrick,
+    interp1!, interp1, sp2mc, mc2sp,
+    get_number_of_aperiodicities, code_aperiodicity, decode_aperiodicity,
+    code_spectral_envelope, decode_spectral_envelope
 
 
 ### Binary dependency loading ###

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -98,3 +98,87 @@ function decode_aperiodicity(coded_aperiodicity, fs,
 
     aperiodicity
 end
+
+
+"""
+$(SIGNATURES)
+
+CodeSpectralEnvelope codes the spectral envelope.
+
+**Parameters**
+
+- `spectrogram` : spectrogram (time sequence of spectral envelope)
+- `fs` : Sampling frequency
+- `fftsize` : FFT size
+- `number_of_dimentions` : Number of dimentions for coded spectral envelope
+
+**Returns**
+
+- `coded_spectral_envelope` : Coded spectral envelope
+"""
+function code_spectral_envelope(spectrogram, fs,
+                                fftsize, number_of_dimentions)
+    nd = number_of_dimentions
+    f0_length = size(spectrogram, 2)
+    coded_spectral_envelope = zeros(Cdouble, nd, f0_length)
+
+    # Array{Cdouble,2} -> Array{Ptr{Cdouble}}
+    ccoded_spectral_envelope = Array{Ptr{Cdouble}}(f0_length)
+    ptrarray2d!(ccoded_spectral_envelope, coded_spectral_envelope)
+
+    # Array{Cdouble,2} -> Array{Ptr{Cdouble}}
+    cspectrogram = Array{Ptr{Cdouble}}(f0_length)
+    ptrarray2d!(cspectrogram, spectrogram)
+
+    ccall((:CodeSpectralEnvelope, libworld), Void,
+          (Ptr{Ptr{Cdouble}}, Cint, Cint, Cint, Cint, Ptr{Ptr{Cdouble}}),
+          cspectrogram, f0_length, fs, fftsize, nd, ccoded_spectral_envelope)
+
+    # Array{Cdouble,2} <- Array{Ptr{Cdouble}}
+    for i=1:f0_length, j=1:nd
+        coded_spectral_envelope[j,i] = unsafe_load(ccoded_spectral_envelope[i], j)
+    end
+
+    coded_spectral_envelope
+end
+
+"""
+$(SIGNATURES)
+
+DecodeSpectralEnvelope decodes the spectral envelope.
+
+**Parameters**
+
+- `coded_spectral_envelope` : Coded spectral envelope
+- `fs` : Sampling frequency
+- `fftsize` : FFT size
+
+**Returns**
+
+- `spectrogram` : decoded spectral envelope
+"""
+function decode_spectral_envelope(coded_spectral_envelope, fs, fftsize)
+    freqbins = fftsize>>1 + 1
+    nd = size(coded_spectral_envelope, 1)
+    f0_length = size(coded_spectral_envelope, 2)
+    spectrogram = zeros(Cdouble, freqbins, f0_length)
+
+    # Array{Cdouble,2} -> Array{Ptr{Cdouble}}
+    ccoded_spectral_envelope = Array{Ptr{Cdouble}}(f0_length)
+    ptrarray2d!(ccoded_spectral_envelope, coded_spectral_envelope)
+
+    # Array{Cdouble,2} -> Array{Ptr{Cdouble}}
+    cspectrogram = Array{Ptr{Cdouble}}(f0_length)
+    ptrarray2d!(cspectrogram, spectrogram)
+
+    ccall((:DecodeSpectralEnvelope, libworld), Void,
+          (Ptr{Ptr{Cdouble}}, Cint, Cint, Cint, Cint, Ptr{Ptr{Cdouble}}),
+          ccoded_spectral_envelope, f0_length, fs, fftsize, nd, cspectrogram)
+
+    # Array{Cdouble,2} <- Array{Ptr{Cdouble}}
+    for i=1:f0_length, j=1:freqbins
+        spectrogram[j,i] = unsafe_load(cspectrogram[i], j)
+    end
+
+    spectrogram
+end


### PR DESCRIPTION
It seems that there's more errors than mel-cepstrum encode/decode (`sp2mc` / `mc2sp`). Might be a bug of WORLD. Add tests with TODO.