### PR TITLE
Switch to using `Project.toml` instead of `REQUIRE`

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,14 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 4 15 * * *
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 5 13 * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,35 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1
   - nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("WORLD"); Pkg.test("WORLD", coverage=true)'
-after_success:
-- julia -e 'using Pkg; cd(Pkg.dir("WORLD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-- julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps);'
-- julia -e 'using Pkg; cd(Pkg.dir("WORLD")); include(joinpath("docs", "make.jl"))'
+
+jobs:
+  allow_failures:
+    - julia: nightly
+  include:
+    - stage: "Documentation"
+      julia: 1.5
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.build("WORLD");
+                                               Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
+
+branches:
+  only:
+  - master
+  - gh-pages # For building documentation
+  - /^testing-.*$/ # testing branches
+  - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
+
+cache:
+  directories:
+  - $HOME/.julia/artifacts
+
+coveralls: true
+codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "WORLD"
+uuid = "0818e8b4-bd9c-59ff-a62a-597382e55725"
+version = "0.6.1"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+BinDeps = "0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1"
+DocStringExtensions = "0.5, 0.6, 0.7, 0.8"
+FFTW = "0.0, 0.1, 0.2, 0.3, 1"
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,27 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.0-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  # - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
     - master
     - /release-.*/
+
+cache:
+  - '%USERPROFILE%\.julia\artifacts'
 
 notifications:
   - provider: Email
@@ -15,20 +30,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "
-        using InteractiveUtils; versioninfo();
-        using Pkg; Pkg.clone(pwd(), \"WORLD\"); Pkg.build(\"WORLD\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "using Pkg; Pkg.test(\"WORLD\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.25"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,9 +3,8 @@ using Documenter, WORLD
 makedocs(
     modules = [WORLD],
     clean   = false,
-    format   = :html,
     sitename = "WORLD.jl",
-    pages = Any["Home" => "index.md"],
+    pages = ["Home" => "index.md"],
 )
 
 deploydocs(


### PR DESCRIPTION
@r9y9 it'd be great if you could tag a new version right after merging this pull request, this package can't currently be installed because of the missing `Project.toml` file.  If you aren't familiar with registration of Julia packages, I recommend using https://github.com/JuliaRegistries/Registrator.jl